### PR TITLE
Gcloud

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,4 +23,4 @@ steps:
       name: "gcr.io/cloud-builders/gcloud"
       args: ["app", "deploy", "--stop-previous-version", "./backend"]
 
-timeout: 1800s
+timeout: 2400s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,4 +23,4 @@ steps:
       name: "gcr.io/cloud-builders/gcloud"
       args: ["app", "deploy", "--stop-previous-version", "./backend"]
 
-timeout: 2400s
+timeout: 2700s

--- a/frontend/app.yaml
+++ b/frontend/app.yaml
@@ -1,3 +1,7 @@
 runtime: custom
 env: flex
 service: frontend
+resources:
+  cpu: 1
+  memory_gb: 1
+  disk_size_gb: 10


### PR DESCRIPTION
Added resources section of frontend app.yaml to prevent 502 errors.
Increased cloudbuild.yaml max timeout time time to 45 minutes.